### PR TITLE
Fix: Reset train metrics at the end of each epoch

### DIFF
--- a/eend/train.py
+++ b/eend/train.py
@@ -329,4 +329,6 @@ if __name__ == '__main__':
             writer.add_scalar(
                 f"dev_{k}", acum_dev_metrics[k] / dev_batches_qty,
                 epoch * dev_batches_qty + i)
+        
+        acum_train_metrics = reset_metrics(acum_train_metrics)
         acum_dev_metrics = reset_metrics(acum_dev_metrics)


### PR DESCRIPTION
Thank you for providing the EEND-EDA code.  

While running the training process, I observed unexpected spikes in `train_loss` and `train_DER` at the beginning of each epoch, as shown in the attached TensorBoard screenshot.

![Picture1](https://github.com/user-attachments/assets/5df1b981-0e5b-455f-aaf7-a6c6f32d4928)

I think that this issue occurs because the `reset_metrics()` function is not called at the end of each epoch.
As a result, the `acum_train_metrics` from the previous epoch might be carried over and affect the computation of the first `writer.add_scalar(...)` call in the next epoch:

```python
if i % args.log_report_batches_num == \
        (args.log_report_batches_num-1):
    for k in acum_train_metrics.keys():
        writer.add_scalar(
            f"train_{k}",
            acum_train_metrics[k] / args.log_report_batches_num,    # this line
            epoch * train_batches_qty + i)
    ...
```

So I added the following line at the end of each epoch to address this:

```python
acum_train_metrics = reset_metrics(acum_train_metrics)
```

Could you please review this?
Thank you!